### PR TITLE
[#103419194] Allow the dea_next MTU property to be configured using spiff

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -669,6 +669,7 @@ properties:
     heartbeat_interval_in_seconds: 10
     rlimit_core: (( merge || 0 ))
     allow_host_access: ~
+    mtu: (( merge || nil ))
 
   loggregator_endpoint:
     shared_secret: (( merge ))


### PR DESCRIPTION

[Use NAT to secure a CF installation on GCE](https://www.pivotaltracker.com/story/show/103419194)
__What__

This PR allows us to set the `dea_next MTU property` as a mergeable parameter 

Having added IP Masquerading to the [Google Compute Platform](https://cloud.google.com/), we discovered an issue affecting deployment of applications using the cloudfoundry java buildpack which fetches cached assets from http://download.run.pivotal.io.

This caused app deployments to hang after displaying:

```
Starting app postgresql-cf-service-broker in org admin / space admin as admin...
-----> Downloaded app package (30M)
```

After investigating the issue by doing the following:

```
$ bosh ssh runner
$ sudo su -
$ /var/vcap/packages/warden/warden/src/wsh/wsh --socket /var/vcap/data/warden/depot/19116tip8u0/run/wshd.sock --user vcap
$ curl -k -v http://download.run.pivotal.io
```

We found that the response was truncated after receiving the http headers

After checking the [MTU](http://searchnetworking.techtarget.com/definition/maximum-transmission-unit) by doing:

```
$ ifconfig
lo        Link encap:Local Loopback  
         inet addr:127.0.0.1  Mask:255.0.0.0
         inet6 addr: ::1/128 Scope:Host
         UP LOOPBACK RUNNING  MTU:65536  Metric:1
         RX packets:0 errors:0 dropped:0 overruns:0 frame:0
         TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:0 
         RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

w-1913hgbclek-1 Link encap:Ethernet  HWaddr 4e:76:04:bc:b4:87  
         inet addr:10.254.0.2  Bcast:10.254.0.3  Mask:255.255.255.252
         inet6 addr: fe80::4c76:4ff:febc:b487/64 Scope:Link
         UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
         RX packets:18 errors:0 dropped:0 overruns:0 frame:0
         TX packets:25 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000 
         RX bytes:1244 (1.2 KB)  TX bytes:1586 (1.5 KB)

```

We changed the `MTU` to 1460 to match the `MTU` on the `runner VM` by doing:

```
ifconfig w-1913hgbclek-1 mtu 1460
```

After this change was made the `curl` command returned the full page successfully.


__How this PR should be reviewed__


I have written this commit to be read in the following narrative:

* The [default mtu in warden is 1500](https://github.com/cloudfoundry/warden/blob/master/warden/config/linux.yml)
    and it is configurable in [warden](https://github.com/cloudfoundry/cf-release/pull/109/files) however it is not a [mergeable option using the cf-job release template](https://github.com/cloudfoundry/cf-release/blob/master/templates/cf-jobs.yml#L652) so I have parameterised it so it is.


__How to test this PR__

This is done in the configuration file for your Cloud Foundry deployment. Simply add the MTU to the `properties` dea_next block in one of your Cloud Foundry `spiff stub` files :

```
properties:
...
  dea_next:
    mtu: 1460
```

__Who should Review this PR__

* Anyone on the core team who hasn't worked on this story i.e. @actionjack and @jimconner

__References__

[Default Compute Engine MTU is 1460 before IPsec is applied](https://cloud.google.com/compute/docs/vpn)
[Interface MTU size for OpenStack use 1454 to avoid problems with rubygems with GRE tunneling](https://github.com/cloudfoundry/cf-release/blob/master/jobs/dea_next/templates/warden.yml.erb)
[GRE Tunnels](https://github.com/cloudfoundry/docs-deploying-cf/blob/master/openstack/troubleshooting.html.md)
